### PR TITLE
Change handling of subdirectories

### DIFF
--- a/gitinfo2.pm
+++ b/gitinfo2.pm
@@ -47,7 +47,12 @@ sub git_info_2 {
         }
     }
 
-    my $GIN = ".git/gitHeadInfo.gin";
+    # When running in a sub-directories of the repo
+    my $REPOBASE = `git rev-parse --show-toplevel`;
+    chomp $REPOBASE;
+    my $GITDIR = "$REPOBASE/.git";
+
+    my $GIN = "$GITDIR/gitHeadInfo.gin";
     my $NGIN = "$GIN.new";
 
     if(length(`git status --porcelain`) == 0){
@@ -61,12 +66,6 @@ sub git_info_2 {
 
         # Hoover up the metadata
         my $metadata =`git --no-pager log -1 --date=short --decorate=short --pretty=format:"shash={%h}, lhash={%H}, authname={%an}, authemail={%ae}, authsdate={%ad}, authidate={%ai}, authudate={%at}, commname={%an}, commemail={%ae}, commsdate={%ad}, commidate={%ai}, commudate={%at}, refnames={%d}, firsttagdescribe={$FIRSTTAG}, reltag={$RELTAG} " HEAD`;
-        
-        # When running in a sub-directories of the repo
-        my $dir = ".git";
-        if (!(-e $dir) and !(-d $dir)) {
-            mkdir($dir);
-        }
 
         open(my $fh,'>',$NGIN);
         print $fh "\\usepackage[".$metadata."]{gitexinfo}\n";


### PR DESCRIPTION
Currently the code, if it fails to detect a .git folder (indicating that it is not the root of a git repository), creates a .git directory in the current directory. This pull request changes it such that it retrieves the root of the git repository, and uses the .git directory inside of the root. This allows multiple projects across different directories to use the same gitHeadInfo.gin, as well as better conforms to how gitinfo2 itself handles the directories.

An additional option/alternate handling could be to take advantage of the "local" option of gitinfo2, creating gitHeadLocal.gin in the local directory rather than $REPOBASE/.git/gitHeadInfo.gin (as in this commit).