### PR TITLE
Added force option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.synctex
 *.synctex.gz
 _markdown_*
+.idea

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Since I'm a user of `latexmk`, I decided to build a small tool that integrates s
     ``` 
   
 - In case you want to allow also 'dirty' repositories to be handles, add the following line to your `.latexmkrc` :
-- 
+ 
     ``` sh
     do './gitinfo2.pm -force';
     ``` 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ Since I'm a user of `latexmk`, I decided to build a small tool that integrates s
     ``` sh
     do './gitinfo2.pm';
     ``` 
-
+  
+- In case you want to allow also 'dirty' repositories to be handles, add the following line to your `.latexmkrc` :
+- 
+    ``` sh
+    do './gitinfo2.pm -force';
+    ``` 
+  
 - Simply use `gitinfo`
     
     In your LaTeX document, please add the following line (feel free to add extra parameters as described in

--- a/gitinfo2.pm
+++ b/gitinfo2.pm
@@ -58,7 +58,13 @@ sub git_info_2 {
         }
     }
 
-    my $GIN = ".git/gitHeadInfo.gin";
+    # When running in a sub-directories of the repo
+    my $REPOBASE = `git rev-parse --show-toplevel`;
+    $REPOBASE =~ s/\s+$//;
+
+    my $GITDIR = "$REPOBASE/.git";
+
+    my $GIN = "$GITDIR/gitHeadInfo.gin";
     my $NGIN = "$GIN.new";
 
     if (length(`git status --porcelain`) == 0 || $force == 1) {
@@ -71,7 +77,7 @@ sub git_info_2 {
         chop($RELTAG);
 
         # Hoover up the metadata
-        my $metadata = `git --no-pager log -1 --date=short --decorate=short --pretty=format:"shash={%h}, lhash={%H}, authname={%an}, authemail={%ae}, authsdate={%ad}, authidate={%ai}, authudate={%at}, commname={%an}, commemail={%ae}, commsdate={%ad}, commidate={%ai}, commudate={%at}, refnames={%d}, firsttagdescribe={$FIRSTTAG}, reltag={$RELTAG} " HEAD`;
+        my $metadata =`git --no-pager log -1 --date=short --decorate=short --pretty=format:"shash={%h}, lhash={%H}, authname={%an}, authemail={%ae}, authsdate={%ad}, authidate={%ai}, authudate={%at}, commname={%an}, commemail={%ae}, commsdate={%ad}, commidate={%ai}, commudate={%at}, refnames={%d}, firsttagdescribe={$FIRSTTAG}, reltag={$RELTAG} " HEAD`;
 
         # When running in a sub-directories of the repo
         my $dir = ".git";

--- a/gitinfo2.pm
+++ b/gitinfo2.pm
@@ -1,3 +1,4 @@
+#!/usr/bin/env perl
 # Copyright 2018 Raphaël P. Barazzutti
 # 
 # GitInfo2LatexMk - v0.2.1

--- a/gitinfo2.pm
+++ b/gitinfo2.pm
@@ -15,18 +15,29 @@
 # do './gitinfo2.pm'
 # 
 # That's it! Now it'd work!
-
+use Getopt::Long;
+use Pod::Usage;
+use strict;
+use warnings FATAL => 'all';
+my $man = 0;
+my $help = 0;
+my $force = 0;
+GetOptions(
+    force    => \$force,
+    'help|?' => \$help,
+    man      => \$man
+);
 sub git_info_2 {
-    
+
     # get file content as a string
-    my $get_file_content = sub {   
-        my ($f)= @_;
+    my $get_file_content = sub {
+        my ($f) = @_;
 
         # do not separate the reads per line
         local $/ = undef;
 
         open FILE, $f or return "";
-        $string = <FILE>;
+        my $string = <FILE>;
 
         close FILE;
         return $string;
@@ -34,57 +45,100 @@ sub git_info_2 {
 
     # compare two files`
     my $cmp = sub {
-        my($a,$b) = @_;
+        my ($file1, $file2) = @_;
 
-        return $get_file_content->($a) ne $get_file_content->($b);
+        return $get_file_content->($file1) ne $get_file_content->($file2);
     };
 
     my $RELEASE_MATCHER = "[0-9]*.*";
 
-    if(%GI2TM_OPTIONS){        
-        if(exists $GI2TM_OPTIONS{"RELEASE_MATCHER"}){
+    if (my %GI2TM_OPTIONS) {
+        if (exists $GI2TM_OPTIONS{"RELEASE_MATCHER"}) {
             $RELEASE_MATCHER = $GI2TM_OPTIONS{"RELEASE_MATCHER"};
         }
     }
 
-    # When running in a sub-directories of the repo
-    my $REPOBASE = `git rev-parse --show-toplevel`;
-    $REPOBASE =~ s/\s+$//;
-
-    my $GITDIR = "$REPOBASE/.git";
-
-    my $GIN = "$GITDIR/gitHeadInfo.gin";
+    my $GIN = ".git/gitHeadInfo.gin";
     my $NGIN = "$GIN.new";
 
-    if(length(`git status --porcelain`) == 0){
+    if (length(`git status --porcelain`) == 0 || $force == 1) {
         # Get the first tag found in the history from the current HEAD
         my $FIRSTTAG = `git describe --tags --always --dirty='-*'`;
-        $FIRSTTAG =~ s/\s+$//;
+        chop($FIRSTTAG);
 
         # Get the first tag in history that looks like a Release
         my $RELTAG = `git describe --tags --long --always --dirty='-*' --match '$RELEASE_MATCHER'`;
-        $RELTAG =~ s/\s+$//;
+        chop($RELTAG);
 
         # Hoover up the metadata
-        my $metadata =`git --no-pager log -1 --date=short --decorate=short --pretty=format:"shash={%h}, lhash={%H}, authname={%an}, authemail={%ae}, authsdate={%ad}, authidate={%ai}, authudate={%at}, commname={%an}, commemail={%ae}, commsdate={%ad}, commidate={%ai}, commudate={%at}, refnames={%d}, firsttagdescribe={$FIRSTTAG}, reltag={$RELTAG} " HEAD`;
+        my $metadata = `git --no-pager log -1 --date=short --decorate=short --pretty=format:"shash={%h}, lhash={%H}, authname={%an}, authemail={%ae}, authsdate={%ad}, authidate={%ai}, authudate={%at}, commname={%an}, commemail={%ae}, commsdate={%ad}, commidate={%ai}, commudate={%at}, refnames={%d}, firsttagdescribe={$FIRSTTAG}, reltag={$RELTAG} " HEAD`;
 
-        open(my $fh,'>',$NGIN);
-        print $fh "\\usepackage[".$metadata."]{gitexinfo}\n";
-        close $fh;  
-    }else{
-        print "GIT UNCLEAN\n";   
+        # When running in a sub-directories of the repo
+        my $dir = ".git";
+        if (!(-e $dir) and !(-d $dir)) {
+            mkdir($dir);
+        }
+
+        open(my $fh, '>', $NGIN);
+        print $fh "\\usepackage[" . $metadata . "]{gitexinfo}\n";
+        close $fh;
+    }
+    else {
+        print "GIT UNCLEAN\n";
     }
 
-    $cmp->($GIN,$NGIN    );
+    $cmp->($GIN, $NGIN);
 
-    if((-e $GIN || -e $NGIN) && $cmp->($GIN, $NGIN)) {
-            print "Status changed, request recompilation\n";
-            $go_mode = 1;
-            unlink($GIN);
-            rename($NGIN, $GIN);
-    } else {
+    if ((-e $GIN || -e $NGIN) && $cmp->($GIN, $NGIN)) {
+        print "Status changed, request recompilation\n";
+        unlink($GIN);
+        rename($NGIN, $GIN);
+    }
+    else {
         unlink($NGIN);
     }
 }
 
+pod2usage(1) if $help == 1;
+pod2usage(-exitval => 0, -verbose => 2) if $man == 1;
 git_info_2();
+
+__END__
+
+=head1 NAME
+
+gitinfo2 - Generate gitinfo file for usage of gitinfo2
+
+=head1 SYNOPSIS
+
+gitinfo2 [-help] [-man] [-force]
+
+ Options:
+   -help            brief help message
+   -man             full documentation
+   -force           force generation of gitinfo, even if the repository is dirty
+
+=head1 OPTIONS
+
+=over 8
+
+=item B<-help>
+
+Print a brief help message and exits.
+
+=item B<-man>
+
+Prints the manual page and exits.
+
+=item B<-force>
+
+Force generation of gitinfo, even if the repository is dirty
+
+
+=back
+
+=head1 DESCRIPTION
+
+B<gitinfo2> can be used together with gitnfo2 to generate the gitinfo file
+
+=cut


### PR DESCRIPTION
Hi Rbarazzutti, 
Thanks for writing this very useful script. It works like a charm!

I only think there should be an option to also allow to use the script for a dirty repository, because gitinfo2 also knows how to deal with a dirty repository: they just add a * at the end of the git hash. 

In this new version I have included a way to pass command line options and added the option '-force'  so that you can force to script to continue, even it is dirty. Perhaps you want to merge this with your script. 

Regards
Eelco